### PR TITLE
Pymol Fixed

### DIFF
--- a/cookbooks/homebrew/CHANGELOG.md
+++ b/cookbooks/homebrew/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.3.1:
+* Changed to use the attribute defined account, which is now by
+* default 'administrator'
+
 ## v1.3.0:
 
 * [COOK-1425] - use new json output format for formula

--- a/cookbooks/homebrew/attributes/default.rb
+++ b/cookbooks/homebrew/attributes/default.rb
@@ -1,1 +1,1 @@
-default["homebrew"]["user"]          = "jclyons"
+default["homebrew"]["user"]          = "administrator"

--- a/cookbooks/homebrew/recipes/default.rb
+++ b/cookbooks/homebrew/recipes/default.rb
@@ -15,7 +15,7 @@ package 'git' do
 end
 
 execute "change /usr/local/lib permissions" do
-  command "chown -R administrator /usr/local/lib"
+  command "chown -R #{node['homebrew']['user']} /usr/local/lib"
   only_if { File.exist? '/usr/local/lib'}
 end
   

--- a/cookbooks/python/CHANGELOG.md
+++ b/cookbooks/python/CHANGELOG.md
@@ -1,0 +1,13 @@
+# CHANGELOG for python
+
+This file is used to list changes made in each version of python.
+
+## 0.2.0:
+
+* python 2.7.3 installed with flag '--with-brewed-tk' and with
+* tk for pymol compatibility.
+
+## 0.1.0:
+
+* Initial release of python
+* Current app version: python => 2.7.3, python3 => 3.3.0

--- a/cookbooks/python/metadata.rb
+++ b/cookbooks/python/metadata.rb
@@ -3,5 +3,5 @@ maintainer_email "jclyons@wesleyan.edu"
 license          "All rights reserved"
 description      "Installs Python and Python3 side-by-side"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
+version          "0.2.0"
 depends          "homebrew"

--- a/cookbooks/python/recipes/mac.rb
+++ b/cookbooks/python/recipes/mac.rb
@@ -1,16 +1,24 @@
 include_recipe "homebrew"
 
-package "sqlite" do
-  version "3.7.14"
-end
+#package "sqlite" do
+#  version "3.7.14"
+#end
 
-execute "brew link -overwrite sqlite" do
-  user node["homebrew"]["user"] 
+#execute "brew link -overwrite sqlite" do
+#  user node["homebrew"]["user"] 
+#end
+
+homebrew_tap "homebrew/dupes"
+package "tk" do
+  version "8.5.13"
+  options "--enable-threads"
 end
 
 package "python" do
   version "2.7.3"
+  options "--with-brewed-tk"
 end
+
 
 package "python3" do
   version "3.3.0"

--- a/cookbooks/schrodinger_pymol/CHANGELOG.md
+++ b/cookbooks/schrodinger_pymol/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file is used to list changes made in each version of schrodinger_pymol.
 
+## 0.2.0:
+
+* Added an alias to avoid a race condition with the start of X11
+* all dependencies are added with python, since the python
+* installation requires a flag in order to be compatible
+* with pymol
+
 ## 0.1.0:
 
 * Initial release of schrodinger_pymol cookbook

--- a/cookbooks/schrodinger_pymol/metadata.rb
+++ b/cookbooks/schrodinger_pymol/metadata.rb
@@ -3,4 +3,5 @@ maintainer_email "rchristensen@wesleyan.edu"
 license          "All rights reserved"
 description      "Compiles and installs PyMOL"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
+version          "0.2.0"
+depends		 "python"

--- a/cookbooks/schrodinger_pymol/recipes/mac.rb
+++ b/cookbooks/schrodinger_pymol/recipes/mac.rb
@@ -12,9 +12,7 @@
 include_recipe "homebrew"
 
 # Tap an auxilary python repo and install Python Megawidgets
-homebrew_tap "samueljohn/python"
-
-# Build and install Python Megawidgets
+homebrew_tap "Homebrew/homebrew-science"
 package "pmw" do
   version "1.3.3"
 end
@@ -26,3 +24,13 @@ homebrew_tap "scicalculator/pymol"
 package "pymol" do
   version "1.5"
 end
+
+# PyMOL will fail to recognize XQuartz because its timeout is too short
+# so we should launch X11.app first, and sleep for a second, and then
+# launch pymol, so we need an alias
+
+execute "alias pymol" do
+  command 'echo "alias pymol=\"open /Applications/Utilities/X11.app;sleep 1; /usr/local/bin/pymol\"" >> /etc/bashrc'
+end
+
+

--- a/cookbooks/xorg_xquartz/CHANGELOG.md
+++ b/cookbooks/xorg_xquartz/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of xorg_xquartz.
 
+## 0.2.0:
+
+* Added alias so programs looking for X11.app with find XQuartz.app
+
 ## 0.1.0:
 
 * Initial release of xorg_xquartz cookbook

--- a/cookbooks/xorg_xquartz/metadata.rb
+++ b/cookbooks/xorg_xquartz/metadata.rb
@@ -3,4 +3,4 @@ maintainer_email "rchristensen@wesleyan.edu"
 license          "All rights reserved"
 description      "Installs XQuartz"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
+version          "0.2.0"

--- a/cookbooks/xorg_xquartz/recipes/mac.rb
+++ b/cookbooks/xorg_xquartz/recipes/mac.rb
@@ -16,3 +16,8 @@ dmg_package "XQuartz-2.7.4.dmg" do
   type "pkg"
   package_id "org.macosforge.xquartz.pkg"
 end
+
+execute "symlink x11" do
+  command "ln -s /Applications/Utilities/XQuartz.app /Applications/Utilities/X11.app"
+  not_if { File.exist?("/Applications/Utilities/X11.app") }
+end


### PR DESCRIPTION
Pymol dependencies resolved, changing both the schrodinger_pymol and python cookbooks.  XQuartz now has a symlink from X11.app, fixing programs not finding XWindows installed.  Homebrew now uses the attribute specified user always, and the default is now 'administrator'.
