### PR TITLE
Roxio Toast Titanium recipe added, ims-events role updated

### DIFF
--- a/cookbooks/adobe_acrobat_pro/CHANGELOG.md
+++ b/cookbooks/adobe_acrobat_pro/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of acrobat.
 
+## 0.3.0:
+
+* Included updates for 11.0.1 and a security patch for 11.0.2
+
 ## 0.2.0:
 
 * Added dock icon creation

--- a/cookbooks/adobe_acrobat_pro/metadata.rb
+++ b/cookbooks/adobe_acrobat_pro/metadata.rb
@@ -3,4 +3,4 @@ maintainer_email "rchristensen@wesleyan.edu"
 license          "All rights reserved"
 description      "Installs Adobe Acrobat Pro XI"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.0"
+version          "0.3.0"

--- a/cookbooks/adobe_acrobat_pro/recipes/mac.rb
+++ b/cookbooks/adobe_acrobat_pro/recipes/mac.rb
@@ -6,6 +6,7 @@
 #
 # All rights reserved - Do Not Redistribute
 #
+# Install base package
 dmg_package "adobe_acrobat_pro_xi-11.0.dmg" do
   app "adobe_acrobat_pro_xi-11.0"
   volumes_dir "adobe_acrobat_pro_xi-11.0"
@@ -16,6 +17,31 @@ dmg_package "adobe_acrobat_pro_xi-11.0.dmg" do
   type "pkg"
   package_id "com.adobe.acrobat.11.viewer.app.pkg.MUI"
 end
+
+# Install first point release update, which is a dependency of all following point releases
+dmg_package "AcrobatUpd11001.dmg" do
+  app "AcrobatUpd11001"
+  volumes_dir "AcrobatUpd11001"
+  dmg_name "AcrobatUpd11001"
+  source "http://baratheon.class.wesleyan.edu/os_x-10.8/adobe_acrobat_pro_xi/AcrobatUpd11001.dmg"
+  checksum "dab9ab5f9705ffde175b07205174736cb14c01755ef83ab376691fa34081feda"
+  action :install
+  type "pkg"
+  package_id "com.adobe.acrobat.a11.AcrobatUpd11001"
+end
+
+# Install the latest security patch
+dmg_package "AcrobatSecUpd11002.dmg" do
+  app "AcrobatSecUpd11002"
+  volumes_dir "AcrobatSecUpd11002"
+  dmg_name "AcrobatSecUpd11002"
+  source "http://baratheon.class.wesleyan.edu/os_x-10.8/adobe_acrobat_pro_xi/AcrobatSecUpd11002.dmg"
+  checksum "88edf1efee233fbd1319b1ded95e766e7a942a2e843d293f248482e40f082077"
+  action :install
+  type "pkg"
+  package_id "com.adobe.acrobat.a11.AcrobatSecUpd11002"
+end
+
 # Download icon
 cookbook_file "/tmp/adobe.png"
 

--- a/cookbooks/adobe_after_effects_cs6/recipes/mac.rb
+++ b/cookbooks/adobe_after_effects_cs6/recipes/mac.rb
@@ -6,15 +6,15 @@
 #
 # All rights reserved - Do Not Redistribute
 #
-dmg_package "adobe_after_effects_cs6-11.0.2.dmg" do
-  app "adobe_after_effects_cs6-11.0.2_Install"
-  volumes_dir "adobe_after_effects_cs6-11.0.2"
+dmg_package "Adobe After Effects CS6" do
+  app "adobe_after_effects_cs6_Install"
+  volumes_dir "adobe_after_effects_cs6"
   dmg_name "adobe_after_effects_cs6-11.0.2"
   source "http://baratheon.class.wesleyan.edu/os_x-10.8/adobe_after_effects_cs6/adobe_after_effects_cs6-11.0.2.dmg"
-  checksum "0d34b54b39689f35d0569bd298e6bddaa61ac32cf58bbabc44246d9465b966c9"
+  checksum "d2e517e4e4c06eb3a9571c38d6057a9847874e382da4e6b3a722ff6bcd04264c"
   action :install
   type "pkg"
-  package_id "com.adobe.Enterprise.install.E771578B-4201-48DD-A429-742EF35760F6"
+  package_id "com.adobe.Enterprise.install.BA86957C-D9C2-41EB-94AB-D30411071D7B"
 end
 
 # Download icon

--- a/cookbooks/adobe_dreamweaver_cs6/CHANGELOG.md
+++ b/cookbooks/adobe_dreamweaver_cs6/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of dreamweaver.
 
+## 0.3.0
+* Current app version: 12.0.3
+
 ## 0.2.0
 
 * Added icon to dock

--- a/cookbooks/adobe_dreamweaver_cs6/metadata.rb
+++ b/cookbooks/adobe_dreamweaver_cs6/metadata.rb
@@ -3,4 +3,4 @@ maintainer_email "rchristensen@wesleyan.edu"
 license          "All rights reserved"
 description      "Installs Adobe Dreamweaver CS6"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.0"
+version          "0.3.0"

--- a/cookbooks/adobe_dreamweaver_cs6/recipes/mac.rb
+++ b/cookbooks/adobe_dreamweaver_cs6/recipes/mac.rb
@@ -7,15 +7,15 @@
 # All rights reserved - Do Not Redistribute
 #
 # Install package
-dmg_package "adobe_dreamweaver_cs6-12.0.3.dmg" do
+dmg_package "Adobe Dreamweaver CS6" do
   app "adobe_dreamweaver_cs6_Install"
-  volumes_dir "adobe_dreamweaver_cs6-12.0.3"
+  volumes_dir "adobe_dreamweaver_cs6"
   dmg_name "adobe_dreamweaver_cs6-12.0.3"
   source "http://baratheon.class.wesleyan.edu/os_x-10.8/adobe_dreamweaver_cs6/adobe_dreamweaver_cs6-12.0.3.dmg"
-  checksum "0d8cd1b0f164fce1728306281a0c1825533e1abb7212736c4613a90f5b4e9afd"
+  checksum "175756cff42c4b08e3b8839c2e06b7f6504f1dc1c7fb548617894265b786ccca"
   action :install
   type "pkg"
-  package_id "com.adobe.Enterprise.install.F0E755A7-73FC-42E6-8ECA-22A3FD95E008"
+  package_id "com.adobe.Enterprise.install.4EB82BB8-81B3-41AB-9FF2-831373B42DFC"
 end
 
 # Download icon

--- a/cookbooks/adobe_flash_professional_cs6/recipes/mac.rb
+++ b/cookbooks/adobe_flash_professional_cs6/recipes/mac.rb
@@ -7,15 +7,15 @@
 # All rights reserved - Do Not Redistribute
 #
 # Install package
-dmg_package "adobe_flash_professional_cs6-12.0.2.dmg" do
-  app "adobe_flash_professional_cs6-12.0.2_Install"
-  volumes_dir "adobe_flash_professional_cs6-12.0.2"
+dmg_package "Adobe Flash Professional CS6" do
+  app "adobe_flash_professional_cs6_Install"
+  volumes_dir "adobe_flash_professional_cs6"
   dmg_name "adobe_flash_professional_cs6-12.0.2"
   source "http://baratheon.class.wesleyan.edu/os_x-10.8/adobe_flash_professional_cs6/adobe_flash_professional_cs6-12.0.2.dmg"
-  checksum "0d17fd67f4cd3228e98d32831dc4c621c7eaed137379f12e1b500abdbdeec31f"
+  checksum "2c7b5b50600ec529c4d6e2389e47349c14b9ccfd0907f2c675a75f89bd3f7349"
   action :install
   type "pkg"
-  package_id "com.adobe.Enterprise.install.C2267962-3047-468F-A7C9-141015421170"
+  package_id "com.adobe.Enterprise.install.BD17182E-2190-476D-BDAC-6E10AE8D75B3"
 end
 
 

--- a/cookbooks/adobe_illustrator_cs6/CHANGELOG.md
+++ b/cookbooks/adobe_illustrator_cs6/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of illustrator.
 
+## 0.3.0:
+* Current app version: 16.0.3
+
 ## 0.2.0:
 
 * Added icon to dock

--- a/cookbooks/adobe_illustrator_cs6/metadata.rb
+++ b/cookbooks/adobe_illustrator_cs6/metadata.rb
@@ -3,4 +3,4 @@ maintainer_email "rchristensen@wesleyan.edu"
 license          "All rights reserved"
 description      "Installs Adobe Illustrator"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.0"
+version          "0.3.0"

--- a/cookbooks/adobe_illustrator_cs6/recipes/mac.rb
+++ b/cookbooks/adobe_illustrator_cs6/recipes/mac.rb
@@ -9,13 +9,13 @@
 # Install package
 dmg_package "adobe_illustrator_cs6-16.0.3.dmg" do
   app "adobe_illustrator_cs6_Install"
-  volumes_dir "adobe_illustrator_cs6-16.0.3"
-  dmg_name "adobe_illustrator_cs6-16.0.3"
-  source "http://baratheon.class.wesleyan.edu/os_x-10.8/adobe_illustrator_cs6/adobe_illustrator_cs6-16.0.3.dmg"
-  checksum "f4fa63d987582f0d5cd690da377a887def19272b826ceee18ea190d3606c4ef4"
+  volumes_dir "adobe_illustrator_cs6"
+  dmg_name "adobe_illustrator_cs6-16.0.4"
+  source "http://baratheon.class.wesleyan.edu/os_x-10.8/adobe_illustrator_cs6/adobe_illustrator_cs6-16.0.4.dmg"
+  checksum "ac13aa242ecc923a544d6495ea62cbaa162a2593c25d2274edefd049ff7445cf"
   action :install
   type "pkg"
-  package_id "com.adobe.Enterprise.install.93E2A28A-EA2B-44A2-8D93-B5816DAAC142"
+  package_id "com.adobe.Enterprise.install.5DFEC601-60E4-435F-9A47-24817F286C7C"
 end
 
 # Download icon

--- a/cookbooks/adobe_indesign_cs6/recipes/mac.rb
+++ b/cookbooks/adobe_indesign_cs6/recipes/mac.rb
@@ -7,15 +7,15 @@
 # All rights reserved - Do Not Redistribute
 #
 # Install package
-dmg_package "adobe_indesign_cs6-8.0.1.dmg" do
-  app "adobe_indesign_cs6-8.0.1_Install"
-  volumes_dir "adobe_indesign_cs6-8.0.1"
+dmg_package "Adobe InDesign CS6" do
+  app "adobe_indesign_cs6_Install"
+  volumes_dir "adobe_indesign_cs6"
   dmg_name "adobe_indesign_cs6-8.0.1"
   source "http://baratheon.class.wesleyan.edu/os_x-10.8/adobe_indesign_cs6/adobe_indesign_cs6-8.0.1.dmg"
-  checksum "59a7664c33fd3b4ec6ecefdbbdecc099fc35fa89be3471820b883ac90b6b4419"
+  checksum "a470e9390599672332da3a9f82b3f091839963e6ed540f8a6dfbc00aef1a60b4"
   action :install
   type "pkg"
-  package_id "com.adobe.Enterprise.install.E5E7BB07-9B18-46F3-B829-E516CD1F9061"
+  package_id "com.adobe.Enterprise.install.CD42F8C2-93BE-4C32-9064-C04F00977A73"
 end
 
 # Download icon

--- a/cookbooks/adobe_photoshop_cs6/CHANGELOG.md
+++ b/cookbooks/adobe_photoshop_cs6/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of photoshop.
 
+## 0.4.0
+* Now installs to Photoshop 13.0.4 directly
+
 ## 0.3.0
 
 * Added patch package to update Photoshop to 13.0.4 in attempt to alleviate launching issues

--- a/cookbooks/adobe_photoshop_cs6/metadata.rb
+++ b/cookbooks/adobe_photoshop_cs6/metadata.rb
@@ -3,4 +3,4 @@ maintainer_email "rchristensen"
 license          "All rights reserved"
 description      "Installs Adobe Photoshop CS6"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.3.0"
+version          "0.4.0"

--- a/cookbooks/adobe_photoshop_cs6/recipes/mac.rb
+++ b/cookbooks/adobe_photoshop_cs6/recipes/mac.rb
@@ -7,28 +7,28 @@
 # All rights reserved - Do Not Redistribute
 #
 # Install package
-dmg_package "adobe_photoshop_cs6-13.0.3.dmg" do
+dmg_package "Adobe Photoshop CS6" do
   app "adobe_photoshop_cs6_Install"
-  volumes_dir "adobe_photoshop_cs6-13.0.3"
-  dmg_name "adobe_photoshop_cs6-13.0.3"
-  source "http://baratheon.class.wesleyan.edu/os_x-10.8/adobe_photoshop_cs6/adobe_photoshop_cs6-13.0.3.dmg"
-  checksum "6ff0fd4c9649752f474ad5ddfa513c99b9680056e9aa299be3c8120bd3fd6037"
+  volumes_dir "adobe_photoshop_cs6"
+  dmg_name "adobe_photoshop_cs6-13.0.4"
+  source "http://baratheon.class.wesleyan.edu/os_x-10.8/adobe_photoshop_cs6/adobe_photoshop_cs6-13.0.4.dmg"
+  checksum "134be16b8134a2a91276e1f89568e274b36a92e705a4753ce45603237b6e170b"
   action :install
   type "pkg"
-  package_id "com.adobe.Enterprise.install.A6A953A3-576E-444D-8E18-4C99E80DB15C"
+  package_id "com.adobe.Enterprise.install.F6603D67-C55B-41CD-B95F-2D05F01D929C"
 end
 
 # Install update
-dmg_package "adobe_photoshop_cs6-13.0.4-update.dmg" do
-  app "adobe_photoshop_cs6-13.0.4_Update"
-  volumes_dir "adobe_photoshop_cs6-13.0.4-update"
-  dmg_name "adobe_photoshop_cs6-13.0.4-update"
-  source "http://baratheon.class.wesleyan.edu/os_x-10.8/adobe_photoshop_cs6/adobe_photoshop_cs6-13.0.4-update.dmg"
-  checksum "d00ae8a2ef6deebad0e13943d6f5ae0c6c93ab561db4471603fd601bf391e791"
-  action :install
-  type "pkg"
-  package_id "com.adobe.Enterprise.install.3AF43FC0-7F50-46E3-A912-54BD0A5E09E91"
-end
+#dmg_package "adobe_photoshop_cs6-13.0.4-update.dmg" do
+#  app "adobe_photoshop_cs6-13.0.4_Update"
+#  volumes_dir "adobe_photoshop_cs6-13.0.4-update"
+#  dmg_name "adobe_photoshop_cs6-13.0.4-update"
+#  source "http://baratheon.class.wesleyan.edu/os_x-10.8/adobe_photoshop_cs6/adobe_photoshop_cs6-13.0.4-update.dmg"
+#  checksum "d00ae8a2ef6deebad0e13943d6f5ae0c6c93ab561db4471603fd601bf391e791"
+#  action :install
+#  type "pkg"
+#  package_id "com.adobe.Enterprise.install.3AF43FC0-7F50-46E3-A912-54BD0A5E09E91"
+#end
 
 # Download icon
 cookbook_file "/tmp/adobe.png"

--- a/cookbooks/adobe_premiere_pro_cs6/CHANGELOG.md
+++ b/cookbooks/adobe_premiere_pro_cs6/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of premierepro.
 
+## 0.3.0
+* Current app version: 6.0.3
+* Name changed to be version independent
+
 ## 0.2.0
 * Added dock icon creation
 * Current app version: 6.0.2

--- a/cookbooks/adobe_premiere_pro_cs6/metadata.rb
+++ b/cookbooks/adobe_premiere_pro_cs6/metadata.rb
@@ -3,4 +3,4 @@ maintainer_email "rchristensen@wesleyan.edu"
 license          "All rights reserved"
 description      "Installs Adobe Premiere Pro CS6"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.0"
+version          "0.3.0"

--- a/cookbooks/adobe_premiere_pro_cs6/recipes/mac.rb
+++ b/cookbooks/adobe_premiere_pro_cs6/recipes/mac.rb
@@ -7,15 +7,15 @@
 # All rights reserved - Do Not Redistribute
 #
 # Install package
-dmg_package "adobe_premiere_pro_cs6-6.0.2.dmg" do
-  app "adobe_premiere_pro_cs6-6.0.2_Install"
-  volumes_dir "adobe_premiere_pro_cs6-6.0.2"
-  dmg_name "adobe_premiere_pro_cs6-6.0.2"
-  source "http://baratheon.class.wesleyan.edu/os_x-10.8/adobe_premiere_pro_cs6/adobe_premiere_pro_cs6-6.0.2.dmg"
-  checksum "c3928ea2b67c04420730d84592bdb14e293baeb876eaf8d38f5df8e96134f7f2"
+dmg_package "Adobe Premiere Pro CS6" do
+  app "adobe_premiere_pro_cs6_Install"
+  volumes_dir "adobe_premiere_pro_cs6"
+  dmg_name "adobe_premiere_pro_cs6-6.0.3"
+  source "http://baratheon.class.wesleyan.edu/os_x-10.8/adobe_premiere_pro_cs6/adobe_premiere_pro_cs6-6.0.3.dmg"
+  checksum "806e8bd3817b4524998f88c00aaf648dbdc6e4e453b22637fb9c5032195e007c"
   action :install
   type "pkg"
-  package_id "com.adobe.Enterprise.install.A39ED404-FAD0-4310-8DC6-C00539826372"
+  package_id "com.adobe.Enterprise.install.C3BF3D3B-BD3F-4EEE-B978-799647D13F2A"
 end
 
 # Download icon

--- a/cookbooks/apple_airport/CHANGELOG.md
+++ b/cookbooks/apple_airport/CHANGELOG.md
@@ -1,0 +1,8 @@
+# CHANGELOG for apple_airport
+
+This file is used to list changes made in each version of apple_airport.
+
+## 0.1.0:
+
+* Initial release of apple_airport cookbook
+* Current app version: 6.2

--- a/cookbooks/apple_airport/README.md
+++ b/cookbooks/apple_airport/README.md
@@ -1,0 +1,14 @@
+Description
+===========
+Updates the bundled OS X AirPort utility to the latest provided by Apple
+
+Requirements
+============
+OS X 10.6.8 or greater
+
+Attributes
+==========
+
+Usage
+=====
+Use the cookbook!

--- a/cookbooks/apple_airport/metadata.rb
+++ b/cookbooks/apple_airport/metadata.rb
@@ -1,0 +1,6 @@
+maintainer       "Wesleyan University"
+maintainer_email "rchristensen@wesleyan.edu"
+license          "All rights reserved"
+description      "Installs/Updates Apple AirPort Utility"
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          "0.1.0"

--- a/cookbooks/apple_airport/recipes/mac.rb
+++ b/cookbooks/apple_airport/recipes/mac.rb
@@ -1,0 +1,18 @@
+#
+# Cookbook Name:: apple_airport
+# Recipe:: mac
+#
+# Copyright 2013, Wesleyan University
+#
+# All rights reserved - Do Not Redistribute
+#
+dmg_package "Apple AirPort Utility" do
+  app "AirPortUtility"
+  volumes_dir "AirPortUtility"
+  dmg_name "AirPortUtility6.2"
+  source "http://baratheon.class.wesleyan.edu/os_x-10.8/apple_airport/AirPortUtility6.2.dmg"
+  checksum "eaaf25a022719e62ade84148ed8553bfe49a700d0662ab9a17f95e3f5bb2ae51"
+  action :install
+  type "pkg"
+  package_id "com.apple.pkg.AirPortUtility"
+end

--- a/cookbooks/apple_itunes/CHANGELOG.md
+++ b/cookbooks/apple_itunes/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of itunes.
 
+## 0.2.1
+
+* App updated to 11.0.2
+
 ## 0.2.0
 
 * App updated to 11.0.1
@@ -9,8 +13,3 @@ This file is used to list changes made in each version of itunes.
 ## 0.1.0:
 
 * Initial release of the iTunes cookbook
-
-- - - 
-Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.
-
-The [Github Flavored Markdown page](http://github.github.com/github-flavored-markdown/) describes the differences between markdown on github and standard markdown.

--- a/cookbooks/apple_itunes/metadata.rb
+++ b/cookbooks/apple_itunes/metadata.rb
@@ -3,4 +3,4 @@ maintainer_email "rchristensen@wesleyan.edu"
 license          "All rights reserved"
 description      "Installs iTunes 11"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.0"
+version          "0.2.1"

--- a/cookbooks/apple_itunes/recipes/mac.rb
+++ b/cookbooks/apple_itunes/recipes/mac.rb
@@ -6,12 +6,12 @@
 #
 # All rights reserved - Do Not Redistribute
 #
-dmg_package "iTunes11.0.1.dmg" do
+dmg_package "iTunes11.0.2.dmg" do
   app "Install iTunes"
   volumes_dir "iTunes"
-  dmg_name "iTunes11.0.1"
-  source "http://baratheon.class.wesleyan.edu/os_x-10.8/apple_itunes/iTunes11.0.1.dmg"
-  checksum "f45610ee3f3755cb4b277fb78f0018e992b05e2f4ebc0fcd0988d31826f7df00"
+  dmg_name "iTunes11.0.2"
+  source "http://baratheon.class.wesleyan.edu/os_x-10.8/apple_itunes/iTunes11.0.2.dmg"
+  checksum "40525df3bc3bb367a0906200b23e211f510a4d565d3c8858dad9f2f9acfeb197"
   action :install
   type "pkg"
   package_id "com.apple.pkg.iTunesX"

--- a/cookbooks/audacity/CHANGELOG.md
+++ b/cookbooks/audacity/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 This file is used to list changes made in each version of audacity.
 
-## 0.1.0:
+## 0.3.0:
 
-* Initial release of audacity cookbook
+* Current version: 2.0.3
 
 ## 0.2.0:
 
 * Mac recipe now installs both LAME and FFmpeg plugins
+
+## 0.1.0:
+
+* Initial release of audacity cookbook
 
 - - - 
 Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.

--- a/cookbooks/audacity/metadata.rb
+++ b/cookbooks/audacity/metadata.rb
@@ -3,4 +3,4 @@ maintainer_email "rchristensen"
 license          "All rights reserved"
 description      "Installs Audacity and LAME/FFmpeg plugins"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.0"
+version          "0.3.0"

--- a/cookbooks/audacity/recipes/mac.rb
+++ b/cookbooks/audacity/recipes/mac.rb
@@ -6,12 +6,12 @@
 #
 # All rights reserved - Do Not Redistribute
 #
-dmg_package "audacity-macosx-ub-2.0.2.dmg" do
+dmg_package "Audacity Mac OSX" do
   app "Audacity"
-  volumes_dir "Audacity 2.0.2"
-  dmg_name "audacity-macosx-ub-2.0.2"
-  source "http://baratheon.class.wesleyan.edu/os_x-10.8/audacity/audacity-macosx-ub-2.0.2.dmg"
-  checksum "1deaa15b9e0cbe2835dfbd3a27d76a91fd9d0fa8182528d0ac077bc5dcc246c1"
+  volumes_dir "Audacity 2.0.3"
+  dmg_name "audacity-macosx-ub-2.0.3"
+  source "http://baratheon.class.wesleyan.edu/os_x-10.8/audacity/audacity-macosx-ub-2.0.3.dmg"
+  checksum "85ae417d4d532986c655b5ce634d7aceff64153d8f7ebab57ac9eb273fae58cb"
   action :install
   type "dir"
 end

--- a/cookbooks/oracle_java/CHANGELOG.md
+++ b/cookbooks/oracle_java/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of oracle_java.
 
+## 0.4.0:
+
+* Updated Oracle Java to 7.0u15.
+* Updated Apple Java to 2013-001.
+
 ## 0.3.0: 
 
 * Updated Oracle Java to 7.0u11 to patch zero-day exploit.

--- a/cookbooks/oracle_java/metadata.rb
+++ b/cookbooks/oracle_java/metadata.rb
@@ -3,4 +3,4 @@ maintainer_email "rchristensen@wesleyan.edu"
 license          "All rights reserved"
 description      "Installs Java for OS X"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.3.0"
+version          "0.4.0"

--- a/cookbooks/oracle_java/recipes/mac.rb
+++ b/cookbooks/oracle_java/recipes/mac.rb
@@ -2,29 +2,29 @@
 # Cookbook Name:: java
 # Recipe:: mac
 #
-# Copyright 2012, Wesleyan University
+# Copyright 2013, Wesleyan University
 #
 # All rights reserved - Do Not Redistribute
 #
-# Installs system-level Java 6 Runtime for applications
-dmg_package "JavaForOSX2012-006" do
+# Installs system-level Java 6 Runtime for applications, disables Java 6 web plug-in
+dmg_package "JavaForOSX2013-001" do
   app "JavaForOSX"
-  volumes_dir "Java for OS X 2012-006"
-  dmg_name "JavaForOSX2012-006"
-  source "http://baratheon.class.wesleyan.edu/os_x-10.8/apple_java/JavaForOSX2012-006.dmg"
-  checksum "6d947f4a20e8f7ee35bb460675ad0b930f8acc15ee0b0dbfc791a7a02abed6c0"
+  volumes_dir "Java for OS X 2013-001"
+  dmg_name "JavaForOSX2013-001"
+  source "http://baratheon.class.wesleyan.edu/os_x-10.8/apple_java/JavaForOSX2013-001.dmg"
+  checksum "5c6f709b747a9c067580accf260a18cadba13ad16203adf8238929b5b2869f8b"
   action :install
   type "pkg"
   package_id "com.apple.pkg.JavaForMacOSX107"
 end
 
-# Installs Java 7 web plugin for Browsers
-dmg_package "jre-7u11-macosx-x64.dmg" do
-  app "Java 7 Update 11"
-  volumes_dir "Java 7 Update 11"
-  dmg_name "jre-7u11-macosx-x64"
-  source "http://baratheon.class.wesleyan.edu/os_x-10.8/oracle_java/jre-7u11-macosx-x64.dmg"
-  checksum "089410645d13b2dd9e6e1551cc7ea0e74d4a26c4f5d50eb7f8a780ff25ac8b71"
+# Installs Java 7 web plug-in for browsers
+dmg_package "jre-7u15-macosx-x64.dmg" do
+  app "Java 7 Update 15"
+  volumes_dir "Java 7 Update 15"
+  dmg_name "jre-7u15-macosx-x64"
+  source "http://baratheon.class.wesleyan.edu/os_x-10.8/oracle_java/jre-7u15-macosx-x64.dmg"
+  checksum "62be342a4ed754f14fad58dbe2ed22820971f271840beb685e232631293c8e96"
   action :install
   type "pkg"
   package_id "com.oracle.jre"

--- a/cookbooks/roxio_toast_titanium/CHANGELOG.md
+++ b/cookbooks/roxio_toast_titanium/CHANGELOG.md
@@ -1,0 +1,8 @@
+# CHANGELOG for roxio_toast_titanium
+
+This file is used to list changes made in each version of roxio_toast_titanium.
+
+## 0.1.0:
+
+* Initial release of roxio_toast_titanium
+* Current version: 11.1.1072

--- a/cookbooks/roxio_toast_titanium/README.md
+++ b/cookbooks/roxio_toast_titanium/README.md
@@ -1,0 +1,68 @@
+roxio_toast_titanium Cookbook
+=============================
+TODO: Enter the cookbook description here.
+
+e.g.
+This cookbook makes your favorite breakfast sandwhich.
+
+Requirements
+------------
+TODO: List your cookbook requirements. Be sure to include any requirements this cookbook has on platforms, libraries, other cookbooks, packages, operating systems, etc.
+
+e.g.
+#### packages
+- `toaster` - roxio_toast_titanium needs toaster to brown your bagel.
+
+Attributes
+----------
+TODO: List you cookbook attributes here.
+
+e.g.
+#### roxio_toast_titanium::default
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['roxio_toast_titanium']['bacon']</tt></td>
+    <td>Boolean</td>
+    <td>whether to include bacon</td>
+    <td><tt>true</tt></td>
+  </tr>
+</table>
+
+Usage
+-----
+#### roxio_toast_titanium::default
+TODO: Write usage instructions for each cookbook.
+
+e.g.
+Just include `roxio_toast_titanium` in your node's `run_list`:
+
+```json
+{
+  "name":"my_node",
+  "run_list": [
+    "recipe[roxio_toast_titanium]"
+  ]
+}
+```
+
+Contributing
+------------
+TODO: (optional) If this is a public cookbook, detail the process for contributing. If this is a private cookbook, remove this section.
+
+e.g.
+1. Fork the repository on Github
+2. Create a named feature branch (like `add_component_x`)
+3. Write you change
+4. Write tests for your change (if applicable)
+5. Run the tests, ensuring they all pass
+6. Submit a Pull Request using Github
+
+License and Authors
+-------------------
+Authors: TODO: List authors

--- a/cookbooks/roxio_toast_titanium/metadata.rb
+++ b/cookbooks/roxio_toast_titanium/metadata.rb
@@ -1,0 +1,7 @@
+name             'roxio_toast_titanium'
+maintainer       'Wesleyan University'
+maintainer_email 'mdietz@wesleyan.edu'
+license          'All rights reserved'
+description      'Installs and updates Roxio Toast Titanium'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'

--- a/cookbooks/roxio_toast_titanium/recipes/mac.rb
+++ b/cookbooks/roxio_toast_titanium/recipes/mac.rb
@@ -9,21 +9,21 @@
 dmg_package "Roxio Toast Titanium" do
   app "Install Toast 11"
   volumes_dir "Toast 11 Titanium"
-  dmg_name "Toast11Titanium.dmg"
+  dmg_name "Toast11Titanium"
   source "http://baratheon.class.wesleyan.edu/os_x-10.8/roxio_toast_titanium/Toast11Titanium.dmg"
   checksum "428e7f185937cf26c87423713d8c167390cefc1612b129f2b38636f0c6c4ce84"
   action :install
-  type "dmg"
+  type "pkg"
 end
 
 dmg_package "Update Toast 11 to 11.1.1072" do
   app "Toast Titanium"
   volumes_dir "Toast Titanium 11.1"
-  dmg_name "toast_titanium-11.1.1072.dmg"
+  dmg_name "toast_titanium-11.1.1072"
   source "http://baratheon.class.wesleyan.edu/os_x-10.8/roxio_toast_titanium/toast_titanium-11.1.1072.dmg"
   checksum "8d6a5f941f924525be200ba3474d1861d0a4a04c4445766d1b8742f1b6d57e27"
   action :install
-  type "dmg"
+  type "pkg"
 end
 
 

--- a/cookbooks/roxio_toast_titanium/recipes/mac.rb
+++ b/cookbooks/roxio_toast_titanium/recipes/mac.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook Name:: toast_11_titanium
+# Recipe:: mac
+#
+# Copyright 2012, Wesleyan University
+#
+# All rights reserved - Do Not Redistribute
+#
+dmg_package "Roxio Toast Titanium" do
+  app "Install Toast 11"
+  volumes_dir "Toast 11 Titanium"
+  dmg_name "Toast11Titanium.dmg"
+  source "http://baratheon.class.wesleyan.edu/os_x-10.8/roxio_toast_titanium/Toast11Titanium.dmg"
+  checksum "428e7f185937cf26c87423713d8c167390cefc1612b129f2b38636f0c6c4ce84"
+  action :install
+  type "dmg"
+end
+
+dmg_package "Update Toast 11 to 11.1.1072" do
+  app "Toast Titanium"
+  volumes_dir "Toast Titanium 11.1"
+  dmg_name "toast_titanium-11.1.1072.dmg"
+  source "http://baratheon.class.wesleyan.edu/os_x-10.8/roxio_toast_titanium/toast_titanium-11.1.1072.dmg"
+  checksum "8d6a5f941f924525be200ba3474d1861d0a4a04c4445766d1b8742f1b6d57e27"
+  action :install
+  type "dmg"
+end
+
+

--- a/roles/ims-events.rb
+++ b/roles/ims-events.rb
@@ -42,6 +42,8 @@ run_list  "recipe[prepare::ims-events]",
           "recipe[apple_compressor::mac]",
           "recipe[apple_final_cut_pro::mac]",
           "recipe[audacity::mac]",
+          "recipe[apple_airport::mac]",
+          "recipe[roxio_toast_titanium::mac]",
           # Finalize 
           "recipe[finalize::mac]"
 #"recipe[remotedesktop::mac]",

--- a/roles/ims-events.rb
+++ b/roles/ims-events.rb
@@ -41,6 +41,7 @@ run_list  "recipe[prepare::ims-events]",
           # Video
           "recipe[apple_compressor::mac]",
           "recipe[apple_final_cut_pro::mac]",
+          "recipe[audacity::mac]",
           # Finalize 
           "recipe[finalize::mac]"
 #"recipe[remotedesktop::mac]",


### PR DESCRIPTION
ims-events now includes Apple Airport, Audacity, and Toast.  The Toast recipe installs Toast 11.0 and updates it to 11.1 successfully on Mac.  Somehow this pull request is also re-marking already accepted changes into master, but I doubt that will effect anything.
