### PR TITLE
The Unarchiver Launch Associations

### DIFF
--- a/cookbooks/unarchiver/recipes/mac.rb
+++ b/cookbooks/unarchiver/recipes/mac.rb
@@ -16,3 +16,43 @@ dmg_package "theunarchiver-3.6.1.dmg" do
   package_id "cx.c3.theunarchiver"
   version "3.6.1"
 end
+
+launch_association_set_file_handler "public.archive" do
+  bundle_id "cx.c3.theunarchiver"
+  all_users true
+end
+
+launch_association_set_file_handler "public.zip-archive.first-part" do
+  bundle_id "cx.c3.theunarchiver"
+  all_users true
+end
+
+launch_association_set_file_handler "cx.c3.compress-tar-archive" do
+  bundle_id "cx.c3.theunarchiver"
+  all_users true
+end
+
+launch_association_set_file_handler "public.tar-bzip2-archive" do
+  bundle_id "cx.c3.theunarchiver"
+  all_users true
+end
+
+launch_association_set_file_handler "org.tukaani.tar-xz-archive" do
+  bundle_id "cx.c3.theunarchiver"
+  all_users true
+end
+
+launch_association_set_file_handler "com.padus.cdi-image" do
+  bundle_id "cx.c3.theunarchiver"
+  all_users true
+end
+
+launch_association_set_file_handler "com.nero.nrg-image" do
+  bundle_id "cx.c3.theunarchiver"
+  all_users true
+end
+
+launch_association_set_file_handler "com.alcohol-soft.mdf-image" do
+  bundle_id "cx.c3.theunarchiver"
+  all_users true
+end


### PR DESCRIPTION
Added launch association for all file types supported by The Unarchiver.
All covered by public.archive were not added specifically.  This list
was generated from TheUnarchiver.app/Content/Info.plist
